### PR TITLE
venus: add vintf for qualcomm diag driver support

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -694,3 +694,6 @@ vendor/firmware/st_fts_k2_htp.ftb
 
 # Vibrator firmware
 vendor/firmware/aw8697_haptic.bin
+
+# Qualcomm diag service
+-vendor/etc/vintf/manifest/vendor.qti.diag.hal.service.xml


### PR DESCRIPTION
Goes along with the vendor changeset with required blobs: https://github.com/davwheat/android_pe_vendor_xiaomi_venus/commit/1e04dfcb8f9d3a952396417c7a4fe1874320fdb8

> This _**might**_ be identical for all sm8350 or all Xiaomi sm8350 devices, but I cannot test on anything other than `venus`.
